### PR TITLE
Enable Vercel deployment for React frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ npm run dev
 ```
 
 The app will be available at `http://localhost:5173`.
+The development server uses `VITE_API_URL` from `.env.development` to proxy API
+requests to the backend. You can adjust this URL if your backend runs on a
+different port.
 
 ### Production build
 
@@ -23,6 +26,14 @@ npm run build
 ```
 
 This will generate the static files in `frontend/dist`.
+
+### Deploying to Vercel
+
+To deploy the frontend on [Vercel](https://vercel.com), create a project with
+the **frontend** folder as the root directory. Set an environment variable named
+`VITE_API_URL` pointing to your backend API base URL (for example,
+`https://my-backend.example.com`). Vercel will run `npm run build` and serve the
+generated files from `frontend/dist`.
 
 ## Backend
 

--- a/frontend/.env.development
+++ b/frontend/.env.development
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -4,12 +4,13 @@ import Chat from './Chat';
 
 export default function App() {
   const [messages, setMessages] = useState([]);
+  const apiBase = import.meta.env.VITE_API_URL || '';
 
   const handleUserMessage = async (text) => {
     const userMessage = { sender: 'user', text };
     setMessages((msgs) => [...msgs, userMessage]);
     try {
-      const res = await fetch('/api/chat', {
+      const res = await fetch(`${apiBase}/api/chat`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ message: text })

--- a/frontend/src/FlightSearch.jsx
+++ b/frontend/src/FlightSearch.jsx
@@ -5,10 +5,11 @@ export default function FlightSearch() {
   const [destination, setDestination] = useState('');
   const [date, setDate] = useState('');
   const [results, setResults] = useState([]);
+  const apiBase = import.meta.env.VITE_API_URL || '';
 
   const handleSearch = async () => {
     try {
-      const res = await fetch('/api/flights', {
+      const res = await fetch(`${apiBase}/api/flights`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ origin, destination, date })

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -1,11 +1,16 @@
-import { defineConfig } from 'vite';
+import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
 
-export default defineConfig({
-  plugins: [react()],
-  server: {
-    proxy: {
-      '/api': 'http://localhost:5000'
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiUrl = env.VITE_API_URL || 'http://localhost:8000';
+
+  return {
+    plugins: [react()],
+    server: {
+      proxy: {
+        '/api': apiUrl
+      }
     }
-  }
+  };
 });

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,12 @@
+{
+  "builds": [
+    {
+      "src": "frontend/package.json",
+      "use": "@vercel/static-build",
+      "config": { "distDir": "dist" }
+    }
+  ],
+  "routes": [
+    { "src": "/(.*)", "dest": "frontend/dist/$1" }
+  ]
+}


### PR DESCRIPTION
## Summary
- load env vars in vite config so the dev server can proxy correctly
- use `VITE_API_URL` when making API requests
- document Vercel deployment
- provide env files for development/example
- add a `vercel.json` config

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6850f90c1a9c8332ab83ca565b0e2327